### PR TITLE
Añadir UI de auth/examen con modo, validaciones y loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # FocusFlow
+
+Interfaz web simple para:
+
+- Alternar entre modo oscuro y claro.
+- Crear cuenta con validación de nombre de usuario, e-mail, contraseña y repetición.
+- Iniciar sesión sin recargar la página, mostrando errores inline.
+- Añadir exámenes indicando inicio de estudio y fecha de examen.
+- Ver loader moderno con spinner y mensaje "Preparando...".
+
+## Ejecutar
+
+Abre `index.html` en el navegador.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,142 @@
+const body = document.body;
+const loader = document.getElementById('loader');
+const themeToggle = document.getElementById('themeToggle');
+const tabs = document.querySelectorAll('.tab');
+const forms = document.querySelectorAll('.form');
+
+const loginForm = document.getElementById('loginForm');
+const loginError = document.getElementById('loginError');
+const loginEmail = document.getElementById('loginEmail');
+const loginPassword = document.getElementById('loginPassword');
+
+const registerForm = document.getElementById('registerForm');
+const regUsername = document.getElementById('regUsername');
+const regEmail = document.getElementById('regEmail');
+const regPassword = document.getElementById('regPassword');
+const regPassword2 = document.getElementById('regPassword2');
+const registerError = document.getElementById('registerError');
+const registerSuccess = document.getElementById('registerSuccess');
+
+const examForm = document.getElementById('examForm');
+const examName = document.getElementById('examName');
+const studyStart = document.getElementById('studyStart');
+const examDate = document.getElementById('examDate');
+const examError = document.getElementById('examError');
+const examList = document.getElementById('examList');
+
+let currentUser = {
+  username: 'demo',
+  email: 'demo@focusflow.com',
+  password: '123456'
+};
+
+const savedTheme = localStorage.getItem('theme');
+if (savedTheme === 'dark') {
+  body.classList.add('dark');
+  themeToggle.textContent = '☀️ Modo claro';
+}
+
+window.addEventListener('load', () => {
+  setTimeout(() => {
+    loader.classList.add('hidden');
+  }, 700);
+});
+
+themeToggle.addEventListener('click', () => {
+  body.classList.toggle('dark');
+  const dark = body.classList.contains('dark');
+  localStorage.setItem('theme', dark ? 'dark' : 'light');
+  themeToggle.textContent = dark ? '☀️ Modo claro' : '🌙 Modo oscuro';
+});
+
+tabs.forEach((tab) => {
+  tab.addEventListener('click', () => {
+    tabs.forEach((t) => t.classList.remove('active'));
+    forms.forEach((f) => f.classList.remove('active'));
+
+    tab.classList.add('active');
+    const target = document.getElementById(`${tab.dataset.tab}Form`);
+    target.classList.add('active');
+
+    loginError.textContent = '';
+    registerError.textContent = '';
+    registerSuccess.textContent = '';
+  });
+});
+
+registerForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  registerError.textContent = '';
+  registerSuccess.textContent = '';
+
+  if (!registerForm.checkValidity()) {
+    registerError.textContent = 'Completa todos los campos correctamente.';
+    return;
+  }
+
+  if (regPassword.value !== regPassword2.value) {
+    registerError.textContent = 'Las contraseñas no coinciden.';
+    return;
+  }
+
+  currentUser = {
+    username: regUsername.value.trim(),
+    email: regEmail.value.trim().toLowerCase(),
+    password: regPassword.value
+  };
+
+  registerSuccess.textContent = 'Cuenta creada. Ya puedes iniciar sesión.';
+  registerForm.reset();
+});
+
+loginForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  loginError.textContent = '';
+
+  const email = loginEmail.value.trim().toLowerCase();
+  const password = loginPassword.value;
+
+  if (!loginForm.checkValidity()) {
+    loginError.textContent = 'Rellena e-mail y contraseña.';
+    return;
+  }
+
+  if (email !== currentUser.email || password !== currentUser.password) {
+    loginError.textContent = 'Contraseña incorrecta o e-mail no registrado.';
+    return;
+  }
+
+  loginError.textContent = 'Inicio de sesión correcto.';
+  loginError.style.color = 'var(--success)';
+  setTimeout(() => {
+    loginError.textContent = '';
+    loginError.style.color = 'var(--danger)';
+  }, 1300);
+});
+
+examForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  examError.textContent = '';
+
+  if (!examForm.checkValidity()) {
+    examError.textContent = 'Completa los datos del examen.';
+    return;
+  }
+
+  const start = new Date(studyStart.value);
+  const exam = new Date(examDate.value);
+
+  if (start > exam) {
+    examError.textContent = 'La fecha de estudio no puede ser posterior al examen.';
+    return;
+  }
+
+  const item = document.createElement('li');
+  item.innerHTML = `
+    <strong>${examName.value.trim()}</strong><br />
+    Inicio de estudio: <b>${studyStart.value}</b><br />
+    Examen: <b>${examDate.value}</b>
+  `;
+  examList.prepend(item);
+  examForm.reset();
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FocusFlow</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div id="loader" class="loader-overlay" aria-live="polite">
+      <div class="spinner" aria-hidden="true"></div>
+      <p>Preparando...</p>
+    </div>
+
+    <header class="topbar fade-in-down">
+      <h1>FocusFlow</h1>
+      <button id="themeToggle" class="btn btn-secondary" type="button" aria-label="Cambiar tema">
+        🌙 Modo oscuro
+      </button>
+    </header>
+
+    <main class="container">
+      <section class="card slide-up" id="auth">
+        <div class="tabs">
+          <button class="tab active" data-tab="login" type="button">Iniciar sesión</button>
+          <button class="tab" data-tab="register" type="button">Crear cuenta</button>
+        </div>
+
+        <form id="loginForm" class="form active" novalidate>
+          <label>
+            E-mail
+            <input type="email" id="loginEmail" required autocomplete="email" />
+          </label>
+          <label>
+            Contraseña
+            <input type="password" id="loginPassword" required autocomplete="current-password" />
+          </label>
+          <p class="error" id="loginError" role="alert"></p>
+          <button class="btn" type="submit">Entrar</button>
+        </form>
+
+        <form id="registerForm" class="form" novalidate>
+          <label>
+            Nombre de usuario
+            <input type="text" id="regUsername" required minlength="3" autocomplete="username" />
+          </label>
+          <label>
+            E-mail
+            <input type="email" id="regEmail" required autocomplete="email" />
+          </label>
+          <label>
+            Contraseña
+            <input type="password" id="regPassword" required minlength="6" autocomplete="new-password" />
+          </label>
+          <label>
+            Repetir contraseña
+            <input type="password" id="regPassword2" required minlength="6" autocomplete="new-password" />
+          </label>
+          <p class="error" id="registerError" role="alert"></p>
+          <p class="success" id="registerSuccess"></p>
+          <button class="btn" type="submit">Crear cuenta</button>
+        </form>
+      </section>
+
+      <section class="card slide-up delayed" id="examSection">
+        <h2>Añadir examen</h2>
+        <form id="examForm" novalidate>
+          <label>
+            Nombre del examen
+            <input type="text" id="examName" required />
+          </label>
+          <label>
+            Fecha de inicio de estudio
+            <input type="date" id="studyStart" required />
+          </label>
+          <label>
+            Fecha del examen
+            <input type="date" id="examDate" required />
+          </label>
+          <p class="error" id="examError" role="alert"></p>
+          <button class="btn" type="submit">Guardar examen</button>
+        </form>
+        <ul id="examList" class="exam-list"></ul>
+      </section>
+    </main>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,246 @@
+:root {
+  --bg: #f5f7ff;
+  --card: #ffffff;
+  --text: #20253a;
+  --muted: #5e6480;
+  --primary: #5d5fef;
+  --danger: #d64545;
+  --success: #138a4f;
+  --border: #d9ddf5;
+  --shadow: 0 12px 30px rgba(24, 40, 92, 0.1);
+}
+
+body.dark {
+  --bg: #111423;
+  --card: #1a1f34;
+  --text: #f0f3ff;
+  --muted: #a9b1d1;
+  --primary: #7c7eff;
+  --danger: #ff7d7d;
+  --success: #4cd197;
+  --border: #2d355c;
+  --shadow: 0 14px 32px rgba(0, 0, 0, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  transition: background 0.35s ease, color 0.35s ease;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+}
+
+.container {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 1rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1.1rem;
+  box-shadow: var(--shadow);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+}
+
+.tabs {
+  display: flex;
+  gap: 0.4rem;
+  margin-bottom: 0.75rem;
+}
+
+.tab,
+.btn {
+  border: none;
+  border-radius: 10px;
+  padding: 0.6rem 0.85rem;
+  cursor: pointer;
+  transition: transform 0.18s ease, filter 0.2s ease, background 0.25s ease;
+}
+
+.tab {
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid var(--border);
+}
+
+.tab.active {
+  color: #fff;
+  background: var(--primary);
+}
+
+.tab:hover,
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.btn {
+  background: var(--primary);
+  color: #fff;
+  font-weight: 600;
+}
+
+.btn-secondary {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text);
+}
+
+.form {
+  display: none;
+  gap: 0.65rem;
+}
+
+.form.active {
+  display: grid;
+  animation: fadeIn 0.25s ease;
+}
+
+label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+input {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text);
+  padding: 0.55rem 0.65rem;
+}
+
+.error {
+  min-height: 1.2rem;
+  color: var(--danger);
+  margin: 0;
+}
+
+.success {
+  min-height: 1.2rem;
+  color: var(--success);
+  margin: 0;
+}
+
+.exam-list {
+  list-style: none;
+  margin: 0.85rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.exam-list li {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.7rem;
+  background: color-mix(in oklab, var(--card), var(--bg) 20%);
+  animation: popIn 0.25s ease;
+}
+
+.loader-overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-content: center;
+  gap: 0.8rem;
+  background: color-mix(in oklab, var(--bg), black 12%);
+  z-index: 999;
+  transition: opacity 0.35s ease;
+}
+
+.loader-overlay.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.spinner {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  border: 4px solid color-mix(in oklab, var(--primary), white 35%);
+  border-top-color: transparent;
+  animation: spin 0.8s linear infinite;
+  margin: 0 auto;
+}
+
+.fade-in-down {
+  animation: fadeDown 0.45s ease;
+}
+
+.slide-up {
+  animation: slideUp 0.45s ease;
+}
+
+.delayed {
+  animation-delay: 0.1s;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeDown {
+  from {
+    opacity: 0;
+    transform: translateY(-12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes popIn {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}


### PR DESCRIPTION
### Motivation
- Implementar la UX solicitada para alternar tema oscuro/claro, crear cuentas (pidiendo nombre de usuario, e-mail, contraseña y repetirla), iniciar sesión sin recargar mostrando errores inline, y añadir exámenes con fecha de inicio de estudio y fecha de examen.
- Mejorar la experiencia con animaciones en transiciones normales y un loader moderno con spinner circular y texto `Preparando...`.

### Description
- Añadidos `index.html`, `styles.css` y `app.js` que contienen la nueva interfaz y la lógica cliente para autenticación, formularios de examen, temas y loader.
- Toggle de tema que persiste la preferencia en `localStorage` y actualiza la etiqueta del botón; estilos y variables CSS incluyen variantes para el modo oscuro.
- Registro: validación del formulario, comprobación de que `regPassword` y `regPassword2` coincidan, creación de `currentUser` en memoria y mensaje de éxito sin recargar la página.
- Inicio de sesión: validación cliente que compara con `currentUser` y muestra mensajes de error inline (no hay refresh) cuando el e-mail o la contraseña son incorrectos.
- Formulario de examen: solicita `studyStart` y `examDate`, valida que la fecha de inicio no sea posterior al examen, inserta la entrada en `#examList` y aplica animaciones; el loader muestra el spinner giratorio y el texto `Preparando...`.

### Testing
- Ejecutado `node --check app.js` y la comprobación ha finalizado correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1e65b211c83329064130e84f3a045)